### PR TITLE
update flumeview-reduce usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ var Flume = require('flumedb')
 
 var db = Flume(MemLog())
   //the api of flumeview-reduce will be mounted at db.sum...
-  .use('sum', Reduce(function (acc, item) {
+  .use('sum', Reduce(1, function (acc, item) {
     return (acc || 0) + item.foo
   }))
 


### PR DESCRIPTION
The example doesn't run as-is: `flumeview-reduce` now requires its
constructor's 1st param to be a version number.