### PR TITLE
Pass opts into flumeview constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,15 @@ function map(obj, iter) {
   return o
 }
 
+function merge (opts, toMerge, overwrite) {
+  Object.keys(toMerge).forEach(key => {
+    if(overwrite || !opts[key])
+      opts[key] = toMerge[key]
+  })
+
+  return opts
+}
+
 module.exports = function (log, isReady) {
   var views = []
   var meta = {}
@@ -30,6 +39,7 @@ module.exports = function (log, isReady) {
     }
   }
 
+  var opts = {}
   var ready = Obv()
   ready.set(isReady !== undefined ? isReady : true)
   var flume = {
@@ -58,7 +68,7 @@ module.exports = function (log, isReady) {
       if(~Object.keys(flume).indexOf(name))
         throw new Error(name + ' is already in use!')
 
-      var sv = createView(log, name)
+      var sv = createView(log, name, opts)
 
       views[name] = flume[name] = wrap(sv, log.since, ready)
       meta[name] = flume[name].meta
@@ -78,6 +88,10 @@ module.exports = function (log, isReady) {
         })
       })
 
+      return flume
+    },
+    useOptions: function (options, overwrite) {
+      merge(opts, options, overwrite)
       return flume
     },
     rebuild: function (cb) {
@@ -116,4 +130,3 @@ module.exports = function (log, isReady) {
   }
   return flume
 }
-

--- a/index.js
+++ b/index.js
@@ -16,18 +16,18 @@ function map(obj, iter) {
   return o
 }
 
-function merge (opts, toMerge, overwrite) {
-  Object.keys(toMerge).forEach(key => {
-    if(overwrite || !opts[key])
-      opts[key] = toMerge[key]
-  })
-
-  return opts
-}
-
-module.exports = function (log, isReady) {
+module.exports = function (log, opts) {
   var views = []
   var meta = {}
+  var isReady
+
+  if ('object' === typeof opts) {
+    opts = opts || {}
+    isReady = opts.ready
+  } else {
+    isReady = opts
+    opts = {}
+  }
 
   log.get = count(log.get, 'get')
 
@@ -39,7 +39,6 @@ module.exports = function (log, isReady) {
     }
   }
 
-  var opts = {}
   var ready = Obv()
   ready.set(isReady !== undefined ? isReady : true)
   var flume = {
@@ -88,10 +87,6 @@ module.exports = function (log, isReady) {
         })
       })
 
-      return flume
-    },
-    useOptions: function (options, overwrite) {
-      merge(opts, options, overwrite)
       return flume
     },
     rebuild: function (cb) {

--- a/test/level.js
+++ b/test/level.js
@@ -1,5 +1,7 @@
 var Flume = require('../')
 var LevelLog = require('flumelog-level')
 
+var testOpts = { InjectedValue: 'injected2' }
+
 require('./memlog')
-  (Flume(LevelLog('/tmp/test_flumedb-levellog'+Date.now())))
+  (Flume(LevelLog('/tmp/test_flumedb-levellog'+Date.now()), testOpts), testOpts)

--- a/test/memlog.js
+++ b/test/memlog.js
@@ -9,7 +9,7 @@ var MemLog = require('flumelog-memory')
 var Reduce = require('flumeview-reduce')
 var Obv = require('obv')
 
-module.exports = function (db) {
+module.exports = function (db, testOpts = {}) {
   db.use('stats', Reduce(1, function (acc, data) {
     return statistics(acc, data.foo)
   }))
@@ -111,7 +111,7 @@ module.exports = function (db) {
   })
 
   tape('opts passing', function (t) {
-    t.plan(3)
+    t.plan(1)
     var obv = Obv()
     var since = db.since.value+1
     obv.set(since)
@@ -125,32 +125,8 @@ module.exports = function (db) {
       close: cb => cb()
     }
 
-    var val1 = 'injected1'
-    db.useOptions({
-      InjectedValue: val1
-    })
-
     db.use('inject', function (log, name, opts) {
-      t.equal(val1, opts.InjectedValue)
-      return emptyView
-    })
-
-    var val2 = 'injected2'
-    db.useOptions({
-      InjectedValue: val2
-    })
-
-    db.use('injectNoOverwrite', function (log, name, opts) {
-      t.equal(val1, opts.InjectedValue)
-      return emptyView
-    })
-
-    db.useOptions({
-      InjectedValue: val2
-    }, true)
-
-    db.use('injectOverwrite', function (log, name, opts) {
-      t.equal(val2, opts.InjectedValue)
+      t.equal(testOpts.InjectedValue, opts.InjectedValue)
       return emptyView
     })
   })

--- a/test/memlog.js
+++ b/test/memlog.js
@@ -24,7 +24,7 @@ module.exports = function (db) {
 
   tape('simple', function (t) {
 
-    db.since(function (v) { 
+    db.since(function (v) {
       console.log("SINCE", v)
     }, false)
 
@@ -110,6 +110,51 @@ module.exports = function (db) {
     })
   })
 
+  tape('opts passing', function (t) {
+    t.plan(3)
+    var obv = Obv()
+    var since = db.since.value+1
+    obv.set(since)
+
+    var emptyView = {
+      methods: {},
+      since: obv,
+      createSink: function (opts) {
+      },
+      destroy: cb => cb(),
+      close: cb => cb()
+    }
+
+    var val1 = 'injected1'
+    db.useOptions({
+      InjectedValue: val1
+    })
+
+    db.use('inject', function (log, name, opts) {
+      t.equal(val1, opts.InjectedValue)
+      return emptyView
+    })
+
+    var val2 = 'injected2'
+    db.useOptions({
+      InjectedValue: val2
+    })
+
+    db.use('injectNoOverwrite', function (log, name, opts) {
+      t.equal(val1, opts.InjectedValue)
+      return emptyView
+    })
+
+    db.useOptions({
+      InjectedValue: val2
+    }, true)
+
+    db.use('injectOverwrite', function (log, name, opts) {
+      t.equal(val2, opts.InjectedValue)
+      return emptyView
+    })
+  })
+
   tape('close', function (t) {
     db.close(function () {
       t.end()
@@ -120,5 +165,3 @@ module.exports = function (db) {
 
 if(!module.parent)
   module.exports(Flume(MemLog()))
-
-

--- a/test/offset.js
+++ b/test/offset.js
@@ -1,5 +1,7 @@
 var Flume = require('../')
 var OffsetLog = require('flumelog-offset')
 
+var testOpts = { InjectedValue: 'injected' }
+
 require('./memlog')
-  (Flume(OffsetLog('/tmp/test_flumedb-offset'+Date.now()+'/log', 1024, require('flumecodec/json'))))
+  (Flume(OffsetLog('/tmp/test_flumedb-offset'+Date.now()+'/log', 1024, require('flumecodec/json')), testOpts), testOpts)


### PR DESCRIPTION
Simple dependency injection controlled by flumedb. It is opt in for the FlumeViews, they can use the flume stores provided in opts or not depending on the requirements of the individual view. Apps hosting a flumedb can then set the opts for that platform with useOptions() so they can inform flumedb what stores are most appropriate for the platform.