### PR TITLE
add option to allow access to indexes before `ready`

### DIFF
--- a/wrap.js
+++ b/wrap.js
@@ -38,10 +38,16 @@ module.exports = function wrap(sv, flume) {
     source: function (fn, name) {
       return function (opts) {
         throwIfClosed(name)
-        meta[name] ++
-        return pull(PullCont(function (cb) {
-          ready(function () { cb(null, fn(opts)) })
-        }), pull.through(function () { meta[name] ++ }))
+        if (opts && opts.awaitReady === false) {
+          // bypass waiting for ready
+          return fn(opts)
+        } else {
+          meta[name] ++
+          return pull(PullCont(function (cb) {
+            ready(function () { cb(null, fn(opts)) })
+          }), pull.through(function () { meta[name] ++ }))
+        }
+
       }
     },
     async: function (fn, name) {


### PR DESCRIPTION
This PR adds an `awaitReady: false` option to index reads by extending the wrap function to check options passed in.

Backlinks example:

```js
ssb.backlinks.read({awaitReady: false, query}) // doesn't wait until indexes complete before starting
```

Not sure if this is the best way to solve the problem (a wee bit magical reading the opts like that), but having this feature is making a massive difference in my initial tests of Patchwork onboarding, so I'm keen to push to get something like this implemented! 

cc @pietgeursen @dominictarr @ahdinosaur @arj03 