### PR TITLE
support out-of-date view requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ If they type is `async` or `source` the actual call to the `flumeview[key]` meth
 be delayed until `flumeview.since` is in up to date with the log.
 `sync` type methods will be called immediately.
 
+If you would rather **_not wait_** for the view to get up to date with the log,
+but just want the data that is already in the index. provide the option
+`since: -1` to the view call. This works for async and source apis.
+If since is a positive number, the view will wait until it's at least up that up to date.
+
 #### flumeview.ready (cb)
 
 A `ready` method is also added to each mounted `flumeview` which takes a callback
@@ -247,4 +252,7 @@ which will be called exactly once, when that view is up to date with the log
 ## License
 
 MIT
+
+
+
 

--- a/index.js
+++ b/index.js
@@ -122,6 +122,7 @@ module.exports = function (log, isReady, mapper) {
 
       views[name] = flume[name] = wrap(sv, flume)
       meta[name] = flume[name].meta
+      //if the view is ahead of the log somehow, destroy the view and rebuild it.
       sv.since.once(function build (upto) {
         log.since.once(function (since) {
           if(upto > since) {


### PR DESCRIPTION
This adds support for out of date view requests.
`sbot.query.read({since: -1, query:...})` will just call the query.read without waiting for the view to fully up to date with the current log - it will just wait for it to have loaded.

This could help with @mmckegg's holding tank idea: `%9jJUwSknOV7vzPcpTAUbwTcDtvb5djsZ1BrvLIlstTw=.sha256` but was easy enough to implement inbetween breakfast and second coffee (first coffee is before breakfast) (there isn't very much time between breakfast and second coffee ;)

I should probably add tests before merging this...