### PR TITLE
Expose `flumedb.views`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ closes all flumeviews.
 
 set to true if `flumedb.close()` has been called
 
+#### flumedb.views => object
+
+flumeviews that are currently being used by flumedb
+
 ---
 
 ### flumelog api

--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ function asyncify () {
 }
 
 module.exports = function (log, isReady, mapper) {
-  var views = []
   var meta = {}
 
   log.get = count(log.get, 'get')
@@ -120,7 +119,7 @@ module.exports = function (log, isReady, mapper) {
         {get: get, stream: stream, since: log.since, filename: log.filename}
         , name)
 
-      views[name] = flume[name] = wrap(sv, flume)
+      flume.views[name] = flume[name] = wrap(sv, flume)
       meta[name] = flume[name].meta
       sv.since.once(function build (upto) {
         log.since.once(function (since) {
@@ -149,7 +148,7 @@ module.exports = function (log, isReady, mapper) {
     },
     rebuild: function (cb) {
       throwIfClosed('rebuild')
-      return cont.para(map(views, function (sv) {
+      return cont.para(map(flume.views, function (sv) {
         return function (cb) {
           sv.destroy(function (err) {
             if(err) return cb(err)
@@ -173,14 +172,15 @@ module.exports = function (log, isReady, mapper) {
     close: function (cb) {
       if(flume.closed) return cb()
       flume.closed = true
-      cont.para(map(views, function (sv, k) {
+      cont.para(map(flume.views, function (sv, k) {
         return function (cb) {
           if(sv.close) sv.close(cb)
           else cb()
         }
       })) (cb)
 
-    }
+    },
+    views: {}
   }
   return flume
 }

--- a/test/memlog.js
+++ b/test/memlog.js
@@ -14,6 +14,14 @@ module.exports = function (db) {
     return statistics(acc, data.foo)
   }))
 
+  tape('views', function (t) {
+    console.log(db)
+    console.log(db.views)
+    t.notEqual(db.views, undefined, 'views are accessible')
+    t.equal(Object.keys(db.views).length, 1, 'view count is correct')
+    t.end()
+  })
+
   tape('empty db', function (t) {
     db.stats.get(function (err, value) {
       if(err) throw err

--- a/test/memlog.js
+++ b/test/memlog.js
@@ -15,8 +15,6 @@ module.exports = function (db) {
   }))
 
   tape('views', function (t) {
-    console.log(db)
-    console.log(db.views)
     t.notEqual(db.views, undefined, 'views are accessible')
     t.equal(Object.keys(db.views).length, 1, 'view count is correct')
     t.end()

--- a/wrap.js
+++ b/wrap.js
@@ -62,7 +62,7 @@ module.exports = function wrap(sv, flume) {
     }
   }
 
-  var o = {ready: ready, since: sv.since, close: sv.close, meta: meta}
+  var o = { ready, since: sv.since, close: sv.close, meta, destroy: sv.destroy }
   if(!sv.methods) throw new Error('a stream view must have methods property')
 
   for(var key in sv.methods) {


### PR DESCRIPTION
Resolves #25 

Previously we were using an array to store the views, but somehow it was being treated like an object so I've made that change. On a side-note, I didn't know that was even possible, but it looks like it is:

```js
const array = []
array['foo'] = 42
console.log(array) // => [ foo: 42 ]
```

Anyway, this includes two small tests but I should mention that it hasn't seen any other use.