### PR TITLE
Fix `sv.destroy()` error

### DIFF
--- a/wrap.js
+++ b/wrap.js
@@ -62,7 +62,7 @@ module.exports = function wrap(sv, flume) {
     }
   }
 
-  var o = {ready: ready, since: sv.since, close: sv.close, meta: meta}
+  var o = {ready: ready, since: sv.since, close: sv.close, meta: meta, destroy: sv.destroy}
   if(!sv.methods) throw new Error('a stream view must have methods property')
 
   for(var key in sv.methods) {


### PR DESCRIPTION
Resolves #27, although I'm not sure that I understand why.

---

My intuition is that these are mandatory methods that all views must export, but I'm not completely clear on why this list isn't all of them in the readme. Otherwise, it makes sense: views must support `destroy()`.