### PR TITLE
Use `setImmediate` to resolve `rm` error

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports = function (log, isReady, mapper) {
             //which will restart the write.
             var rm = sv.since(function (v) {
               if(v === log.since.value) {
-                rm()
+                setImmediate(() => rm())
                 cb()
               }
             })


### PR DESCRIPTION
This resolves an issue where `rm()` can be undefined when the observable has already been set. When the problem occurs, the callback executes immediately, before the expression finishes, and `rm` isn't defined until the next tick. This resolves the issue by ensuring that the expression resolves and `rm` is defined *before* calling it.

Backlink: `%/9eWjHC8txoDMFneS71ASlgj8K0eWOy1Wh90Hp9rafQ=.sha256`