### PR TITLE
Fix rebuild callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,12 +163,7 @@ module.exports = function (log, isReady, mapper) {
             })
           })
         }
-      }))
-      (function (err) {
-        if(err) cb(err) //hopefully never happens
-
-        //then restream each streamview, and callback when it's uptodate with the main log.
-      })
+      }))(cb)
     },
     close: function (cb) {
       if(flume.closed) return cb()


### PR DESCRIPTION
Previously it looks like `rebuild()` was never actually calling the original callback, so this resolves that issue by calling `cb()` and passing along the error (if any).