### PR TITLE
Add `del()` method that deletes items from log and view

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,20 +44,6 @@ module.exports = function (log, isReady, mapper) {
     }
   }
 
-  function rebuildView (sv, cb) {
-    sv.destroy(function (err) {
-      if(err) return cb(err)
-      //destroy should close the sink stream,
-      //which will restart the write.
-      sv.since(function (v) {
-        // TODO: remove this listener
-        if(v === log.since.value) {
-          cb()
-        }
-      })
-    })
-  }
-
   var ready = Obv()
   ready.set(isReady !== false ? true : undefined)
 
@@ -127,33 +113,7 @@ module.exports = function (log, isReady, mapper) {
     },
     del: function (seq, cb) {
       throwIfClosed('del')
-      log.since.once(() => log.del(seq, (err) => {
-        if (err) return cb(err)
-
-        // Delete item from each view, then callback.
-        Promise.all(Object.values(views).map(view =>
-          new Promise((resolve, reject) => {
-
-            // Simple callback handler for promises.
-            const promiseCb = (err) => {
-              if (err) {
-                reject(err)
-              } else {
-                resolve()
-              }
-            }
-
-            if (typeof view.del === 'function') {
-              // If view supports deletion, use `flumeview.del()` method.
-              view.del(seq, promiseCb)
-            } else {
-              // Otherwise, rebuild the view.
-              rebuildView(view, promiseCb)
-            }
-          })
-        )).catch((err) => cb(err))
-          .then(() => cb(null, seq)) 
-      }))
+      log.since.once(() => log.del(seq, cb))
     },
     use: function (name, createView) {
       if(~Object.keys(flume).indexOf(name))

--- a/index.js
+++ b/index.js
@@ -151,8 +151,8 @@ module.exports = function (log, isReady, mapper) {
               rebuildView(view, promiseCb)
             }
           })
-        )).then(() => cb(null, seq))
-          .catch((err) => cb(err))
+        )).catch((err) => cb(err))
+          .then(() => cb(null, seq)) 
       }))
     },
     use: function (name, createView) {

--- a/index.js
+++ b/index.js
@@ -44,6 +44,20 @@ module.exports = function (log, isReady, mapper) {
     }
   }
 
+  function rebuildView (sv, cb) {
+    sv.destroy(function (err) {
+      if(err) return cb(err)
+      //destroy should close the sink stream,
+      //which will restart the write.
+      sv.since(function (v) {
+        // TODO: remove this listener
+        if(v === log.since.value) {
+          cb()
+        }
+      })
+    })
+  }
+
   var ready = Obv()
   ready.set(isReady !== false ? true : undefined)
 
@@ -110,6 +124,36 @@ module.exports = function (log, isReady, mapper) {
       log.since.once(function () {
         get(seq, cb)
       })
+    },
+    del: function (seq, cb) {
+      throwIfClosed('del')
+      log.since.once(() => log.del(seq, (err) => {
+        if (err) return cb(err)
+
+        // Delete item from each view, then callback.
+        Promise.all(Object.values(views).map(view =>
+          new Promise((resolve, reject) => {
+
+            // Simple callback handler for promises.
+            const promiseCb = (err) => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve()
+              }
+            }
+
+            if (typeof view.del === 'function') {
+              // If view supports deletion, use `flumeview.del()` method.
+              view.del(seq, promiseCb)
+            } else {
+              // Otherwise, rebuild the view.
+              rebuildView(view, promiseCb)
+            }
+          })
+        )).then(() => cb(null, seq))
+          .catch((err) => cb(err))
+      }))
     },
     use: function (name, createView) {
       if(~Object.keys(flume).indexOf(name))


### PR DESCRIPTION
Depends on https://github.com/flumedb/flumelog-offset/pull/16

Passes deletions to `flumelog.del()` as well as `flumeview.del()`. If `flumeview.del()` doesn't exist for a view, this forces a rebuild of the view from scratch.