### PR TITLE
Add basic flumelog methods support

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,6 +181,20 @@ module.exports = function (log, isReady, mapper) {
     },
     views: {}
   }
+
+  for(var key in log.methods) {
+    var type = log.methods[key]
+    var fn = log[key]
+    if(typeof fn !== 'function') {
+      throw new Error(`expected function named: "${key}" of type: "${type}"`)
+    }
+    if(flume[key] != null) {
+      throw new Error(`log method "${key}" conflicts with flumedb method of the same name`)
+    }
+
+    flume[key] = log[key]
+  }
+
   return flume
 }
 


### PR DESCRIPTION
I think we should probably be using some of the infrastructure from `wrap` but I'm unclear on how flumelog methods should interact with meta. Should it just take `flume.meta.log`?

Obsoletes #33 