### PR TITLE
well defined close behaviour

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,12 @@ module.exports = function (log, isReady, mapper) {
           if(sv.close) sv.close(cb)
           else cb()
         }
-      })) (cb)
+      })) (function (err) {
+        if(!log.close)
+          cb(err)
+        else
+          log.close(cb)
+      })
 
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "devDependencies": {
     "flumecodec": "0.0.1",
-    "flumelog-level": "^0.0.4",
-    "flumelog-memory": "^0.1.3",
-    "flumelog-offset": "^3.3.1",
-    "flumeview-reduce": "^1.3.13",
+    "flumelog-level": "0.0.4",
+    "flumelog-memory": "^1.0.2",
+    "flumelog-offset": "^3.4.2",
+    "flumeview-reduce": "^1.3.16",
     "statistics": "^3.3.0",
     "tape": "^4.6.2"
   },

--- a/test/memlog.js
+++ b/test/memlog.js
@@ -15,6 +15,8 @@ module.exports = function (db) {
   }))
 
   tape('empty db', function (t) {
+    t.ok(db.stats.close, 'stats view has close method')
+
     db.stats.get(function (err, value) {
       if(err) throw err
       t.equal(value, undefined)
@@ -105,7 +107,8 @@ module.exports = function (db) {
           reset = true
           obv.set(-1)
           cb()
-        }
+        },
+        close: function (cb) { cb () }
       }
     })
   })
@@ -137,7 +140,7 @@ module.exports = function (db) {
 
 }
 
-if(!module.parent)
+if(!module.parent) {
   function map (value, cb) {
     setImmediate(function () {
       cb(null, value)
@@ -145,7 +148,4 @@ if(!module.parent)
   }
   module.exports(Flume(MemLog()))
   module.exports(Flume(MemLog(), null, map))
-
-
-
-
+}

--- a/wrap.js
+++ b/wrap.js
@@ -40,7 +40,10 @@ module.exports = function wrap(sv, flume) {
         throwIfClosed(name)
         meta[name] ++
         return pull(PullCont(function (cb) {
-          ready(function () { cb(null, fn(opts)) })
+          ready(function (err) {
+            if(err) cb(err)
+            else cb(null, fn(opts))
+          })
         }), pull.through(function () { meta[name] ++ }))
       }
     },
@@ -48,8 +51,9 @@ module.exports = function wrap(sv, flume) {
       return function (opts, cb) {
         throwIfClosed(name)
         meta[name] ++
-        ready(function () {
-          fn(opts, cb)
+        ready(function (err) {
+          if(err) cb(err)
+          else fn(opts, cb)
         })
       }
     },
@@ -62,7 +66,25 @@ module.exports = function wrap(sv, flume) {
     }
   }
 
-  var o = {ready: ready, since: sv.since, close: sv.close, meta: meta, destroy: sv.destroy}
+
+  function _close (err) {
+    while(waiting.length)
+      waiting.shift().cb(err)
+  }
+
+  var o = {
+    ready: ready,
+    since: sv.since,
+    close: function (err, cb) {
+      if('function' == typeof err)
+        cb = err, err = null
+      _close(err || new Error('closed'))
+      if(sv.close.length == 1) sv.close(cb)
+      else                     sv.close(err, cb)
+    },
+    meta: meta,
+    destroy: sv.destroy
+  }
   if(!sv.methods) throw new Error('a stream view must have methods property')
 
   for(var key in sv.methods) {
@@ -75,10 +97,7 @@ module.exports = function wrap(sv, flume) {
   }
 
   o.methods = sv.methods
-
   return o
 }
-
-
 
 


### PR DESCRIPTION
when the database closes, any currently delayed calls to views will error.

should close https://github.com/flumedb/flumedb/issues/35 I just made it wrap close in a way so that any delayed calls are cancelled with an error on close.