### PR TITLE
throw naughty views

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,6 +119,10 @@ module.exports = function (log, isReady, mapper) {
         {get: get, stream: stream, since: log.since, filename: log.filename}
         , name)
 
+      if (typeof sv.close !== 'function') {
+        throw new Error('views in this version of flumedb require a .close method')
+      }
+
       flume.views[name] = flume[name] = wrap(sv, flume)
       meta[name] = flume[name].meta
 

--- a/test/memlog.js
+++ b/test/memlog.js
@@ -119,6 +119,24 @@ module.exports = function (db) {
     })
   })
 
+  tape('throws if you *use* a view without close method', function (t) {
+    t.plan(1)
+    t.throws(
+      () => {
+        db.use('naughtyView', function (log, name) {
+          return {
+            methods: {},
+            since: db.since,
+            createSink: function (opts) { },
+            destroy: function (cb) { }
+            // close: function (cb) { cb () } // << this is missing, so throw
+          }
+        })
+      },
+      /views in this version of flumedb require a .close method/
+    )
+  })
+
   tape('close', function (t) {
     db.close(function () {
       t.end()


### PR DESCRIPTION
with this new version of flumedb we expect all views added with db.use
to have a `view.close(cb)` method.
In upgrading ssb-server I found I was wishing I was told explicitly when a view
was not meeting this expectation. This PR adds that functionality!