### PR TITLE
Be specific when throwing required method error

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,9 +119,18 @@ module.exports = function (log, isReady, mapper) {
         {get: get, stream: stream, since: log.since, filename: log.filename}
         , name)
 
-      if (typeof sv.close !== 'function') {
-        throw new Error('views in this version of flumedb require a .close method')
-      }
+      const requiredMethods = [
+        'close',
+        'createSink',
+        'destroy',
+        'since'
+      ]
+
+      requiredMethods.forEach((methodName) => {
+        if (typeof sv[methodName] !== 'function') {
+          throw new Error(`FlumeDB view '${name}' must implement method '${methodName}'`)
+        }
+      })
 
       flume.views[name] = flume[name] = wrap(sv, flume)
       meta[name] = flume[name].meta

--- a/test/memlog.js
+++ b/test/memlog.js
@@ -133,7 +133,7 @@ module.exports = function (db) {
           }
         })
       },
-      /views in this version of flumedb require a .close method/
+      /Error: FlumeDB view 'naughtyView' must implement method 'close'/
     )
   })
 


### PR DESCRIPTION
Problem: The 'required method' error doesn't specify which view is
missing the method, and only checks the `close()` method.

Solution: Ensure that all required methods exist and throw a specific
error that announces the view name and missing method if one is missing.