### PR TITLE
Fix splicing a callback into the waiting[] array

### DIFF
--- a/wrap.js
+++ b/wrap.js
@@ -41,8 +41,10 @@ module.exports = function wrap(sv, flume) {
       else {
         //find the right point to insert this value.
         for(var i = waiting.length - 2; i > 0; i--) {
-          waiting[i].seq <= after
-          waiting.splice({seq: after, cb: cb}, i+1, 0)
+          if(waiting[i].seq <= after) {
+            waiting.splice(i+1, 0, { seq: after, cb: cb})
+            break
+          }
         }
       }
     } else {


### PR DESCRIPTION
- it called `splice()` for *every* item in the array (missing `if` statement)
- the parameters to splice() were in the wrong order

NOTE: made this PR in the web interface without any kind of testing. So someone should run the tests before merging. I just stumbled upon this piece of code that doesn't make sense.