### PR TITLE
Convert to StandardJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,24 @@ which gives us the freedom to have many different sorts of views!
 Take one `flumelog-*` module and zero or more `flumeview-*` modules,
 and glue them together with `flumedb`.
 
-``` js
+```javascript
 var MemLog = require('flumelog-memory') // just store the log in memory
-var Reduce = require('flumeview-reduce') //just a reduce function.
+var Reduce = require('flumeview-reduce') // just a reduce function.
 var Flume = require('flumedb')
 
 var db = Flume(MemLog())
-  //the api of flumeview-reduce will be mounted at db.sum...
-  .use('sum', Reduce(1, function (acc, item) {
-    return (acc || 0) + item.foo
-  }))
+  // the api of flumeview-reduce will be mounted at db.sum...
+  .use(
+    'sum',
+    Reduce(1, function (acc, item) {
+      return (acc || 0) + item.foo
+    })
+  )
 
-db.append({foo: 1}, function (err, seq) {
+db.append({ foo: 1 }, function (err, seq) {
+  if (err) throw err
   db.sum.get(function (err, value) {
-    if(err) throw err
+    if (err) throw err
     console.log(value) // 1
   })
 })
@@ -78,29 +82,29 @@ will grow much longer than the list of log modules.
 
 ### logs
 
-* [flumedb/flumelog-offset](https://github.com/flumedb/flumelog-offset) a log in a _file_ *recommended*.
-* [flumedb/flumelog-memory](https://github.com/flumedb/flumelog-memory) a log that is just an in memory array.
-* [flumedb/flumelog-level](https://github.com/flumedb/flumelog-level) a log on level.
-* [flumedb/flumelog-idb](https://github.com/flumedb/flumelog-idb) flumelog on top of indexeddb.
+- [flumedb/flumelog-offset](https://github.com/flumedb/flumelog-offset) a log in a _file_ _recommended_.
+- [flumedb/flumelog-memory](https://github.com/flumedb/flumelog-memory) a log that is just an in memory array.
+- [flumedb/flumelog-level](https://github.com/flumedb/flumelog-level) a log on level.
+- [flumedb/flumelog-idb](https://github.com/flumedb/flumelog-idb) flumelog on top of indexeddb.
 
 ### views
 
-* [flumedb/flumeview-reduce](https://github.com/flumedb/flumeview-reduce) a reduce function as a view.
-* [flumedb/flumeview-level](https://github.com/flumedb/flumeview-level) an implemented index on level.
-* [flumedb/flumeview-query](https://github.com/flumedb/flumeview-query) functional query language.
-* [flumedb/flumeview-search](https://github.com/flumedb/flumeview-search) full text search.
-* [flumedb/flumeview-hashtable](https://github.com/flumedb/flumeview-hashtable) hashtable is ideal when you have uniqueish keys and do not need range queries.
-* [flumedb/flumeview-bloom](https://github.com/flumedb/flumeview-bloom) bloom filter lets you check if _may_ have something.
+- [flumedb/flumeview-reduce](https://github.com/flumedb/flumeview-reduce) a reduce function as a view.
+- [flumedb/flumeview-level](https://github.com/flumedb/flumeview-level) an implemented index on level.
+- [flumedb/flumeview-query](https://github.com/flumedb/flumeview-query) functional query language.
+- [flumedb/flumeview-search](https://github.com/flumedb/flumeview-search) full text search.
+- [flumedb/flumeview-hashtable](https://github.com/flumedb/flumeview-hashtable) hashtable is ideal when you have uniqueish keys and do not need range queries.
+- [flumedb/flumeview-bloom](https://github.com/flumedb/flumeview-bloom) bloom filter lets you check if _may_ have something.
 
 ### other
 
 other modules that may come in handy
 
-* [flumedb/flumecodec](https://github.com/flumedb/flumecodec) simple codecs, used in most views and logs.
-* [dominictarr/charwise](https://github.com/dominictarr/charwise) an order-preserving encoding compatible with bytewise, but faster.
-* [flumedb/flumecli](https://github.com/flumedb/flumecli) instance command line interface
-* [flumedb/aligned-block-file](https://github.com/flumedb/aligned-block-file) read and write to a file with aligned blocks that are easy to cache.
-* [flumedb/test-flumelog](https://github.com/flumedb/test-flumelog) reusable tests for a flumelog.
+- [flumedb/flumecodec](https://github.com/flumedb/flumecodec) simple codecs, used in most views and logs.
+- [dominictarr/charwise](https://github.com/dominictarr/charwise) an order-preserving encoding compatible with bytewise, but faster.
+- [flumedb/flumecli](https://github.com/flumedb/flumecli) instance command line interface
+- [flumedb/aligned-block-file](https://github.com/flumedb/aligned-block-file) read and write to a file with aligned blocks that are easy to cache.
+- [flumedb/test-flumelog](https://github.com/flumedb/test-flumelog) reusable tests for a flumelog.
 
 ## api
 
@@ -256,7 +260,3 @@ which will be called exactly once, when that view is up to date with the log
 ## License
 
 MIT
-
-
-
-

--- a/index.js
+++ b/index.js
@@ -8,26 +8,15 @@ var explain = require('explain-error')
 var Looper = require('pull-looper')
 var asyncMap = require('pull-stream/throughs/async-map')
 
-//take a log, and return a log driver.
-//the log has an api with `read`, `get` `since`
+// take a log, and return a log driver.
+// the log has an api with `read`, `get` `since`
 
 var wrap = require('./wrap')
 
-function map(obj, iter) {
+function map (obj, iter) {
   var o = {}
-  for(var k in obj)
-    o[k] = iter(obj[k], k, obj)
+  for (var k in obj) o[k] = iter(obj[k], k, obj)
   return o
-}
-
-function asyncify () {
-  return function (read) {
-    return function (abort, cb) {
-      setImmediate(function () {
-        read(abort, cb)
-      })
-    }
-  }
 }
 
 module.exports = function (log, isReady, mapper) {
@@ -38,7 +27,7 @@ module.exports = function (log, isReady, mapper) {
   function count (fn, name) {
     meta[name] = meta[name] || 0
     return function (a, b) {
-      meta[name] ++
+      meta[name]++
       fn.call(this, a, b)
     }
   }
@@ -46,49 +35,48 @@ module.exports = function (log, isReady, mapper) {
   var ready = Obv()
   ready.set(isReady !== false ? true : undefined)
 
-  var mapStream = opts => {
-    if (opts.values === false)
+  var mapStream = (opts) => {
+    if (opts.values === false) {
       return
-    else if (opts.seqs === false)
+    }
+    if (opts.seqs === false) {
       return asyncMap(mapper)
-    else
-      return asyncMap((data, cb) => {
-        mapper(data.value, (err, value) => {
-          if(err) cb(err)
-          else {
-            data.value = value
-            cb(err, data)
-          }
-        })
+    }
+
+    return asyncMap((data, cb) => {
+      mapper(data.value, (err, value) => {
+        if (err) cb(err)
+        else {
+          data.value = value
+          cb(err, data)
+        }
       })
+    })
   }
 
   function get (seq, cb) {
-    if(mapper)
+    if (mapper) {
       log.get(seq, function (err, value) {
-        if(err) cb(err)
+        if (err) cb(err)
         else mapper(value, cb)
       })
-    else
-      log.get(seq, cb)
+    } else log.get(seq, cb)
   }
 
   function stream (opts) {
-    return pull(
-        log.stream(opts),
-        mapper ? mapStream(opts) : null,
-        Looper
-      )
+    return pull(log.stream(opts), mapper ? mapStream(opts) : null, Looper)
   }
 
-  function throwIfClosed(name) {
-    if(flume.closed) throw new Error('cannot call:'+name+', flumedb instance closed')
+  function throwIfClosed (name) {
+    if (flume.closed) {
+      throw new Error('cannot call:' + name + ', flumedb instance closed')
+    }
   }
 
   var flume = {
     closed: false,
     dir: log.filename ? path.dirname(log.filename) : null,
-    //stream from the log
+    // stream from the log
     since: log.since,
     ready: ready,
     meta: meta,
@@ -111,31 +99,30 @@ module.exports = function (log, isReady, mapper) {
       })
     },
     use: function (name, createView) {
-      if(~Object.keys(flume).indexOf(name))
+      if (~Object.keys(flume).indexOf(name)) {
         throw new Error(name + ' is already in use!')
+      }
       throwIfClosed('use')
 
       var sv = createView(
-        {get: get, stream: stream, since: log.since, filename: log.filename}
-        , name)
+        { get: get, stream: stream, since: log.since, filename: log.filename },
+        name
+      )
 
-      const requiredMethods = [
-        'close',
-        'createSink',
-        'destroy',
-        'since'
-      ]
+      const requiredMethods = ['close', 'createSink', 'destroy', 'since']
 
       requiredMethods.forEach((methodName) => {
         if (typeof sv[methodName] !== 'function') {
-          throw new Error(`FlumeDB view '${name}' must implement method '${methodName}'`)
+          throw new Error(
+            `FlumeDB view '${name}' must implement method '${methodName}'`
+          )
         }
       })
 
       flume.views[name] = flume[name] = wrap(sv, flume)
       meta[name] = flume[name].meta
 
-      //if the view is ahead of the log somehow, destroy the view and rebuild it.
+      // if the view is ahead of the log somehow, destroy the view and rebuild it.
       sv.since.once(function build (upto) {
         const rebuildView = () => {
           // TODO - create some debug logfile and log that we're rebuilding, what error was
@@ -144,19 +131,20 @@ module.exports = function (log, isReady, mapper) {
         }
 
         log.since.once(function (since) {
-          if(upto > since) rebuildView()
+          if (upto > since) rebuildView()
           else {
-            var opts = {gt: upto, live: true, seqs: true, values: true}
-            if (upto == -1)
-              opts.cache = false
+            var opts = { gt: upto, live: true, seqs: true, values: true }
+            if (upto === -1) opts.cache = false
 
             pull(
               stream(opts),
               Looper,
               sv.createSink(function (err) {
-                if(!flume.closed) {
+                if (!flume.closed) {
                   if (err) {
-                    console.error(explain(err, `rebuilding ${name} after view stream error`))
+                    console.error(
+                      explain(err, `rebuilding ${name} after view stream error`)
+                    )
                     rebuildView()
                   } else {
                     sv.since.once(build)
@@ -172,53 +160,58 @@ module.exports = function (log, isReady, mapper) {
     },
     rebuild: function (cb) {
       throwIfClosed('rebuild')
-      return cont.para(map(flume.views, function (sv) {
-        return function (cb) {
-          //destroying will stop createSink stream
-          //and flumedb will restart write.
-          sv.destroy(function (err) {
-            if(err) return cb(err)
-            //when the view is up to date with log again
-            //callback, but only once, and then stop observing.
-            //(note, rare race condition where sv might already be set,
-            //so called before rm is returned)
-            var rm = sv.since(function (v) {
-              if(v === log.since.value) {
-                var _cb = cb; cb = null; _cb()
-              }
-              if(!cb && rm) rm()
+      return cont.para(
+        map(flume.views, function (sv) {
+          return function (cb) {
+            // destroying will stop createSink stream
+            // and flumedb will restart write.
+            sv.destroy(function (err) {
+              if (err) return cb(err)
+              // when the view is up to date with log again
+              // callback, but only once, and then stop observing.
+              // (note, rare race condition where sv might already be set,
+              // so called before rm is returned)
+              var rm = sv.since(function (v) {
+                if (v === log.since.value) {
+                  var _cb = cb
+                  cb = null
+                  _cb()
+                }
+                if (!cb && rm) rm()
+              })
             })
-          })
-        }
-      }))(cb)
+          }
+        })
+      )(cb)
     },
     close: function (cb) {
-      if(flume.closed) return cb()
+      if (flume.closed) return cb()
       flume.closed = true
-      cont.para(map(flume.views, function (sv, k) {
-        return function (cb) {
-          if(sv.close) sv.close(cb)
-          else cb()
-        }
-      })) (function (err) {
-        if(!log.close)
-          cb(err)
-        else
-          log.close(cb)
+      cont.para(
+        map(flume.views, function (sv, k) {
+          return function (cb) {
+            if (sv.close) sv.close(cb)
+            else cb()
+          }
+        })
+      )(function (err) {
+        if (!log.close) cb(err)
+        else log.close(cb)
       })
-
     },
     views: {}
   }
 
-  for(var key in log.methods) {
+  for (var key in log.methods) {
     var type = log.methods[key]
     var fn = log[key]
-    if(typeof fn !== 'function') {
+    if (typeof fn !== 'function') {
       throw new Error(`expected function named: "${key}" of type: "${type}"`)
     }
-    if(flume[key] != null) {
-      throw new Error(`log method "${key}" conflicts with flumedb method of the same name`)
+    if (flume[key] != null) {
+      throw new Error(
+        `log method "${key}" conflicts with flumedb method of the same name`
+      )
     }
 
     flume[key] = log[key]
@@ -226,4 +219,3 @@ module.exports = function (log, isReady, mapper) {
 
   return flume
 }
-

--- a/test/level.js
+++ b/test/level.js
@@ -1,13 +1,9 @@
 var Flume = require('../')
 var LevelLog = require('flumelog-level')
 
-require('./memlog')
-  (Flume(LevelLog('/tmp/test_flumedb-levellog'+Date.now())))
+require('./memlog')(Flume(LevelLog('/tmp/test_flumedb-levellog' + Date.now())))
 
-
-//XXX there is a bug in flumelog-level!
-//something to do with inconsistent support for stream options, seqs, values ?
-//require('./memlog-map')
+// XXX there is a bug in flumelog-level!
+// something to do with inconsistent support for stream options, seqs, values ?
+// require('./memlog-map')
 //  (LevelLog('/tmp/test_flumedb-levellog-map'+Date.now()))
-
-

--- a/test/memlog-map.js
+++ b/test/memlog-map.js
@@ -8,32 +8,35 @@ module.exports = function (log) {
   var errorEnabled = false
 
   var db = Flume(log, true, (val, cb) => {
-    console.log("MAP", val)
-    if(val === undefined) throw new Error('weird: val is undefined')
+    console.log('MAP', val)
+    if (val === undefined) throw new Error('weird: val is undefined')
     setTimeout(() => {
-      if (true === errorEnabled) {
+      if (errorEnabled === true) {
         return cb(new Error('error enabled for testing'))
       }
-      val = val != undefined ? JSON.parse(JSON.stringify(val)) : undefined
-      val.called = (val.called  || 0) + 1
+      val = val !== undefined ? JSON.parse(JSON.stringify(val)) : undefined
+      val.called = (val.called || 0) + 1
       val.map = true
       cb(null, val)
     }, Math.random() * 10)
   })
 
-  db.use('called', Reduce(1, function (acc, data) {
-    return (acc || 0) + data.called
-  }))
+  db.use(
+    'called',
+    Reduce(1, function (acc, data) {
+      return (acc || 0) + data.called
+    })
+  )
 
   tape('get map', function (t) {
     db.since(function (v) {
-      console.log("SINCE", v)
+      console.log('SINCE', v)
     }, false)
 
-    db.append({foo: 1}, function (err, seq) {
-      if(err) throw err
+    db.append({ foo: 1 }, function (err, seq) {
+      if (err) throw err
       db.get(seq, function (err, value) {
-        if(err) throw err
+        if (err) throw err
         t.deepEqual(value.foo, 1)
         t.deepEqual(value.map, true)
         t.deepEqual(value.called, 1)
@@ -43,14 +46,17 @@ module.exports = function (log) {
   })
 
   tape('stream map only values', function (t) {
-    db.append({foo: 2}, function (err, seq) {
-      if(err) throw err
-      console.log("GET", err, seq)
+    db.append({ foo: 2 }, function (err, seq) {
+      if (err) throw err
+      console.log('GET', err, seq)
       pull(
-        db.stream({seqs: false, values: true }),
+        db.stream({ seqs: false, values: true }),
         pull.collect(function (err, ary) {
-          if(err) throw err
-          t.deepEqual(ary, [ { foo: 1, called: 1, map: true }, { foo: 2, called: 1, map: true } ])
+          if (err) throw err
+          t.deepEqual(ary, [
+            { foo: 1, called: 1, map: true },
+            { foo: 2, called: 1, map: true }
+          ])
           t.end()
         })
       )
@@ -58,14 +64,18 @@ module.exports = function (log) {
   })
 
   tape('stream map only seqs', function (t) {
-    db.append({foo: 3}, function (err, seq) {
-      if(err) throw err
-      console.log("GET", err, seq)
+    db.append({ foo: 3 }, function (err, seq) {
+      if (err) throw err
+      console.log('GET', err, seq)
       pull(
-        db.stream({seqs: true, values: false }),
+        db.stream({ seqs: true, values: false }),
         pull.collect(function (err, ary) {
-          if(err) throw err
-          t.ok(ary.every(function (e) { return 'number' === typeof e }))
+          if (err) throw err
+          t.ok(
+            ary.every(function (e) {
+              return typeof e === 'number'
+            })
+          )
           t.end()
         })
       )
@@ -73,19 +83,24 @@ module.exports = function (log) {
   })
 
   tape('stream map values and seqs', function (t) {
-    db.append({foo: 4}, function (err, seq) {
-      if(err) throw err
-      console.log("GET", err, seq)
+    db.append({ foo: 4 }, function (err, seq) {
+      if (err) throw err
+      console.log('GET', err, seq)
       pull(
-        db.stream({seqs: true, values: true }),
+        db.stream({ seqs: true, values: true }),
         pull.collect(function (err, ary) {
-          if(err) throw err
-          t.deepEqual(ary.map(function (e) { return e.value }),  [
-            { foo: 1, called: 1, map: true },
-            { foo: 2, called: 1, map: true },
-            { foo: 3, called: 1, map: true },
-            { foo: 4, called: 1, map: true }
-          ])
+          if (err) throw err
+          t.deepEqual(
+            ary.map(function (e) {
+              return e.value
+            }),
+            [
+              { foo: 1, called: 1, map: true },
+              { foo: 2, called: 1, map: true },
+              { foo: 3, called: 1, map: true },
+              { foo: 4, called: 1, map: true }
+            ]
+          )
           t.end()
         })
       )
@@ -96,25 +111,25 @@ module.exports = function (log) {
     t.ok(db.called)
     db.called.get(null, function (err, count) {
       console.log(err, count)
-      if(err) throw err
+      if (err) throw err
       t.equal(count, 4)
       t.end()
     })
   })
 
-//  tape('get map with error', function (t) {
-//    errorEnabled = true
-//    db.append({foo: 13}, function (err, seq) {
-//      if(err) throw err
-//      console.log("GET", err, seq)
-//      db.get(seq, function (err, value) {
-//        console.log(  "GET", err, value)
-//        t.ok(err)
-//        t.end()
-//      })
-//    })
-//  })
-//
+  //  tape('get map with error', function (t) {
+  //    errorEnabled = true
+  //    db.append({foo: 13}, function (err, seq) {
+  //      if(err) throw err
+  //      console.log("GET", err, seq)
+  //      db.get(seq, function (err, value) {
+  //        console.log(  "GET", err, value)
+  //        t.ok(err)
+  //        t.end()
+  //      })
+  //    })
+  //  })
+  //
 
   tape('close', function (t) {
     db.close(function () {
@@ -123,6 +138,4 @@ module.exports = function (log) {
   })
 }
 
-if(!module.parent)
-  module.exports(MemLog())
-
+if (!module.parent) module.exports(MemLog())

--- a/test/memlog.js
+++ b/test/memlog.js
@@ -10,9 +10,12 @@ var Reduce = require('flumeview-reduce')
 var Obv = require('obv')
 
 module.exports = function (db) {
-  db.use('stats', Reduce(1, function (acc, data) {
-    return statistics(acc, data.foo)
-  }))
+  db.use(
+    'stats',
+    Reduce(1, function (acc, data) {
+      return statistics(acc, data.foo)
+    })
+  )
 
   tape('views', function (t) {
     t.notEqual(db.views, undefined, 'views are accessible')
@@ -24,24 +27,23 @@ module.exports = function (db) {
     t.ok(db.stats.close, 'stats view has close method')
 
     db.stats.get(function (err, value) {
-      if(err) throw err
+      if (err) throw err
       t.equal(value, undefined)
       t.end()
     })
   })
 
   tape('simple', function (t) {
-
-    db.since(function (v) { 
-      console.log("SINCE", v)
+    db.since(function (v) {
+      console.log('SINCE', v)
     }, false)
 
-    db.append({foo: 1}, function (err, seq) {
-      if(err) throw err
-      console.log("GET", err, seq, db.stats)
+    db.append({ foo: 1 }, function (err, seq) {
+      if (err) throw err
+      console.log('GET', err, seq, db.stats)
       db.stats.get([], function (err, value) {
-        if(err) throw err
-        console.log(  "GET", value)
+        if (err) throw err
+        console.log('GET', value)
         t.deepEqual(value.mean, 1)
         t.deepEqual(value.stdev, 0)
         t.end()
@@ -50,12 +52,12 @@ module.exports = function (db) {
   })
 
   tape('append', function (t) {
-    db.append({foo: 3}, function (err, seq) {
-      if(err) throw err
-      console.log("GET", err, seq)
+    db.append({ foo: 3 }, function (err, seq) {
+      if (err) throw err
+      console.log('GET', err, seq)
       db.stats.get([], function (err, value) {
-        if(err) throw err
-        console.log(  "GET", value)
+        if (err) throw err
+        console.log('GET', value)
         t.deepEqual(value.mean, 2)
         t.deepEqual(value.stdev, 1)
         t.end()
@@ -65,38 +67,37 @@ module.exports = function (db) {
 
   tape('get items in stream', function (t) {
     pull(
-      db.stream({seqs: true, values: false}),
+      db.stream({ seqs: true, values: false }),
       pull.asyncMap(function (seq, cb) {
         db.get(seq, cb)
       }),
       pull.collect(function (err, ary) {
-        if(err) throw err
-        t.deepEqual(ary, [{foo: 1}, {foo: 3}])
+        if (err) throw err
+        t.deepEqual(ary, [{ foo: 1 }, { foo: 3 }])
         t.end()
       })
     )
-
   })
 
   tape('disable ready to stall all reads', function (t) {
     var called = false
     db.ready.set(false)
     db.stats.get([], function (err, value) {
+      t.error(err)
       called = true
     })
     setTimeout(function () {
       t.equal(db.ready.value, false)
       t.equal(called, false)
       db.ready.set(true)
-      t.equal(called, true) //this should fire immediately
+      t.equal(called, true) // this should fire immediately
       t.end()
     }, 100)
-
   })
 
   tape('rebuild a view that is ahead', function (t) {
     var obv = Obv()
-    var since = db.since.value+1
+    var since = db.since.value + 1
     obv.set(since)
     var reset = false
     db.use('ahead', function (log, name) {
@@ -105,7 +106,10 @@ module.exports = function (db) {
         since: obv,
         createSink: function (opts) {
           console.log(obv.value, db.since.value)
-          t.ok(obv.value <= db.since.value, 'createSink should not be called unless within an acceptable range')
+          t.ok(
+            obv.value <= db.since.value,
+            'createSink should not be called unless within an acceptable range'
+          )
           t.ok(reset)
           t.end()
         },
@@ -114,27 +118,26 @@ module.exports = function (db) {
           obv.set(-1)
           cb()
         },
-        close: function (cb) { cb () }
+        close: function (cb) {
+          cb()
+        }
       }
     })
   })
 
   tape('throws if you *use* a view without close method', function (t) {
     t.plan(1)
-    t.throws(
-      () => {
-        db.use('naughtyView', function (log, name) {
-          return {
-            methods: {},
-            since: db.since,
-            createSink: function (opts) { },
-            destroy: function (cb) { }
-            // close: function (cb) { cb () } // << this is missing, so throw
-          }
-        })
-      },
-      /Error: FlumeDB view 'naughtyView' must implement method 'close'/
-    )
+    t.throws(() => {
+      db.use('naughtyView', function (log, name) {
+        return {
+          methods: {},
+          since: db.since,
+          createSink: function (opts) {},
+          destroy: function (cb) {}
+          // close: function (cb) { cb () } // << this is missing, so throw
+        }
+      })
+    }, /Error: FlumeDB view 'naughtyView' must implement method 'close'/)
   })
 
   tape('close', function (t) {
@@ -145,15 +148,17 @@ module.exports = function (db) {
 
   tape('append after close', function (t) {
     try {
-      db.append({bar: 4}, function (err, data, seq) {
+      db.append({ bar: 4 }, function (err, data, seq) {
+        t.error(err)
         t.fail('should have thrown')
       })
     } catch (err) {
       t.ok(err)
-//      t.end()
+      //      t.end()
     }
     try {
       db.stats.get(function (err, data, seq) {
+        t.error(err)
         t.fail('should have thrown')
       })
     } catch (err) {
@@ -161,11 +166,10 @@ module.exports = function (db) {
     }
     t.end()
   })
-
 }
 
-if(!module.parent) {
-  function map (value, cb) {
+if (!module.parent) {
+  const map = (value, cb) => {
     setImmediate(function () {
       cb(null, value)
     })

--- a/test/offset.js
+++ b/test/offset.js
@@ -1,18 +1,33 @@
 var Flume = require('../')
 var OffsetLog = require('flumelog-offset')
 
-require('./memlog')
-  (Flume(OffsetLog('/tmp/test_flumedb-offset'+Date.now()+'/log', 1024, require('flumecodec/json'))))
-require('./memlog')
-  (Flume(
-    OffsetLog('/tmp/test_flumedb-offset'+Date.now()+'/log', 1024, require('flumecodec/json')),
+require('./memlog')(
+  Flume(
+    OffsetLog(
+      '/tmp/test_flumedb-offset' + Date.now() + '/log',
+      1024,
+      require('flumecodec/json')
+    )
+  )
+)
+require('./memlog')(
+  Flume(
+    OffsetLog(
+      '/tmp/test_flumedb-offset' + Date.now() + '/log',
+      1024,
+      require('flumecodec/json')
+    ),
     null,
     function (val, cb) {
       cb(null, val)
     }
-))
+  )
+)
 
-require('./memlog-map')
-  (OffsetLog('/tmp/test_flumedb-offset2'+Date.now()+'/log', 1024, require('flumecodec/json')))
-
-
+require('./memlog-map')(
+  OffsetLog(
+    '/tmp/test_flumedb-offset2' + Date.now() + '/log',
+    1024,
+    require('flumecodec/json')
+  )
+)

--- a/wrap.js
+++ b/wrap.js
@@ -1,55 +1,61 @@
 var PullCont = require('pull-cont')
 var pull = require('pull-stream')
 
-module.exports = function wrap(sv, flume) {
-  var since = flume.since, isReady = flume.ready
+module.exports = function wrap (sv, flume) {
+  var since = flume.since
+  var isReady = flume.ready
   var waiting = []
 
   var meta = {}
 
-  function throwIfClosed(name) {
-    if(flume.closed) throw new Error('cannot call:'+name+', flumedb instance closed')
+  function throwIfClosed (name) {
+    if (flume.closed) {
+      throw new Error('cannot call:' + name + ', flumedb instance closed')
+    }
   }
 
   sv.since(function (upto) {
-    if(!isReady.value) return
-    while(waiting.length && waiting[0].seq <= upto)
-      waiting.shift().cb()
+    if (!isReady.value) return
+    while (waiting.length && waiting[0].seq <= upto) waiting.shift().cb()
   })
 
   isReady(function (ready) {
-    if(!ready) return
+    if (!ready) return
     var upto = sv.since.value
-    if(upto == undefined) return
-    while(waiting.length && waiting[0].seq <= upto)
-      waiting.shift().cb()
+    if (upto == null) return
+    while (waiting.length && waiting[0].seq <= upto) waiting.shift().cb()
   })
 
   function ready (cb, after) {
-    //view is already up to date with log, we can just go.
-    if(isReady.value && since.value != null && since.value === sv.since.value)  
+    // view is already up to date with log, we can just go.
+    if (
+      isReady.value &&
+      since.value != null &&
+      since.value === sv.since.value
+    ) {
       cb()
-    //use since: -1 to say you don't care about waiting. just give anything.
-    //we still want to wait until the view has actually loaded. but it doesn't
-    //need to be compared to the log's value.
-    else if(after < 0) {
+    } else if (after < 0) {
+      // use since: -1 to say you don't care about waiting. just give anything.
+      // we still want to wait until the view has actually loaded. but it doesn't
+      // need to be compared to the log's value.
       sv.since.once(cb)
-    }
-    else if(after) {
-      if(!waiting.length || waiting[waiting.length - 1].seq <= after)
-        waiting.push({seq: after, cb: cb})
-      else {
-        //find the right point to insert this value.
-        for(var i = waiting.length - 2; i > 0; i--) {
-          waiting[i].seq <= after
-          waiting.splice({seq: after, cb: cb}, i+1, 0)
+    } else if (after) {
+      if (!waiting.length || waiting[waiting.length - 1].seq <= after) {
+        waiting.push({ seq: after, cb: cb })
+      } else {
+        // find the right point to insert this value.
+        for (var i = waiting.length - 2; i > 0; i--) {
+          if (waiting[i].seq <= after) {
+            waiting.splice({ seq: after, cb: cb }, i + 1, 0)
+            break
+          }
         }
       }
     } else {
       since.once(function (upto) {
-        if(flume.closed) cb(new Error('flumedb: closed before log ready'))
-        else if(isReady.value && upto === sv.since.value) cb()
-        else waiting.push({seq: upto, cb: cb})
+        if (flume.closed) cb(new Error('flumedb: closed before log ready'))
+        else if (isReady.value && upto === sv.since.value) cb()
+        else waiting.push({ seq: upto, cb: cb })
       })
     }
   }
@@ -58,16 +64,23 @@ module.exports = function wrap(sv, flume) {
     source: function (fn, name) {
       return function (opts) {
         throwIfClosed(name)
-        meta[name] ++
-        return pull(PullCont(function (cb) {
-          ready(function () { cb(null, fn(opts)) }, opts && opts.since)
-        }), pull.through(function () { meta[name] ++ }))
+        meta[name]++
+        return pull(
+          PullCont(function (cb) {
+            ready(function () {
+              cb(null, fn(opts))
+            }, opts && opts.since)
+          }),
+          pull.through(function () {
+            meta[name]++
+          })
+        )
       }
     },
     async: function (fn, name) {
       return function (opts, cb) {
         throwIfClosed(name)
-        meta[name] ++
+        meta[name]++
         ready(function () {
           fn(opts, cb)
         }, opts && opts.since)
@@ -76,37 +89,40 @@ module.exports = function wrap(sv, flume) {
     sync: function (fn, name) {
       return function (a, b) {
         throwIfClosed(name)
-        meta[name] ++
+        meta[name]++
         return fn(a, b)
       }
     }
   }
 
   function _close (err) {
-    while(waiting.length)
-      waiting.shift().cb(err)
+    while (waiting.length) waiting.shift().cb(err)
   }
 
   var o = {
     ready: ready,
     since: sv.since,
     close: function (err, cb) {
-      if('function' == typeof err)
-        cb = err, err = null
+      if (typeof err === 'function') {
+        cb = err
+        err = null
+      }
       _close(err || new Error('flumedb:view closed'))
-      if(sv.close.length == 1) sv.close(cb)
-      else                     sv.close(err, cb)
+      if (sv.close.length === 1) sv.close(cb)
+      else sv.close(err, cb)
     },
     meta: meta,
     destroy: sv.destroy
   }
-  if(!sv.methods) throw new Error('a stream view must have methods property')
+  if (!sv.methods) throw new Error('a stream view must have methods property')
 
-  for(var key in sv.methods) {
+  for (var key in sv.methods) {
     var type = sv.methods[key]
     var fn = sv[key]
-    if(typeof fn !== 'function') throw new Error('expected function named:'+key+'of type: '+type)
-    //type must be either source, async, or sync
+    if (typeof fn !== 'function') {
+      throw new Error('expected function named:' + key + 'of type: ' + type)
+    }
+    // type must be either source, async, or sync
     meta[key] = 0
     o[key] = wrapper[type](fn, key)
   }


### PR DESCRIPTION
Problem: Having an inconsistent style makes the code harder to use,
improve, and especially diff between branches.

Solution: I like using code style tools like Prettier, but in the
subculture surrounding FlumeDB it's more common to use StandardJS, which
does both code style and linting. This commit was generated with:

    npx prettier --write . && npx standard --fix

Which converted to Prettier syntax and then flipped that into the
StandardJS style. This means that it also fixed our Markdown. :upside_down_face: 