### PR TITLE
resurrect missing tests

### DIFF
--- a/test/util/memlog-map.js
+++ b/test/util/memlog-map.js
@@ -1,0 +1,138 @@
+var pull = require('pull-stream')
+var tape = require('tape')
+var Reduce = require('flumeview-reduce')
+var Flume = require('../..')
+
+module.exports = function (log) {
+  var errorEnabled = false
+
+  var db = Flume(log, true, (val, cb) => {
+    console.log('MAP', val)
+    if (val === undefined) throw new Error('weird: val is undefined')
+    setTimeout(() => {
+      if (errorEnabled === true) {
+        return cb(new Error('error enabled for testing'))
+      }
+      val = val !== undefined ? JSON.parse(JSON.stringify(val)) : undefined
+      val.called = (val.called || 0) + 1
+      val.map = true
+      cb(null, val)
+    }, Math.random() * 10)
+  })
+
+  db.use(
+    'called',
+    Reduce(1, function (acc, data) {
+      return (acc || 0) + data.called
+    })
+  )
+
+  tape('get map', function (t) {
+    db.since(function (v) {
+      console.log('SINCE', v)
+    }, false)
+
+    db.append({ foo: 1 }, function (err, seq) {
+      if (err) throw err
+      db.get(seq, function (err, value) {
+        if (err) throw err
+        t.deepEqual(value.foo, 1)
+        t.deepEqual(value.map, true)
+        t.deepEqual(value.called, 1)
+        t.end()
+      })
+    })
+  })
+
+  tape('stream map only values', function (t) {
+    db.append({ foo: 2 }, function (err, seq) {
+      if (err) throw err
+      console.log('GET', err, seq)
+      pull(
+        db.stream({ seqs: false, values: true }),
+        pull.collect(function (err, ary) {
+          if (err) throw err
+          t.deepEqual(ary, [
+            { foo: 1, called: 1, map: true },
+            { foo: 2, called: 1, map: true }
+          ])
+          t.end()
+        })
+      )
+    })
+  })
+
+  tape('stream map only seqs', function (t) {
+    db.append({ foo: 3 }, function (err, seq) {
+      if (err) throw err
+      console.log('GET', err, seq)
+      pull(
+        db.stream({ seqs: true, values: false }),
+        pull.collect(function (err, ary) {
+          if (err) throw err
+          t.ok(
+            ary.every(function (e) {
+              return typeof e === 'number'
+            })
+          )
+          t.end()
+        })
+      )
+    })
+  })
+
+  tape('stream map values and seqs', function (t) {
+    db.append({ foo: 4 }, function (err, seq) {
+      if (err) throw err
+      console.log('GET', err, seq)
+      pull(
+        db.stream({ seqs: true, values: true }),
+        pull.collect(function (err, ary) {
+          if (err) throw err
+          t.deepEqual(
+            ary.map(function (e) {
+              return e.value
+            }),
+            [
+              { foo: 1, called: 1, map: true },
+              { foo: 2, called: 1, map: true },
+              { foo: 3, called: 1, map: true },
+              { foo: 4, called: 1, map: true }
+            ]
+          )
+          t.end()
+        })
+      )
+    })
+  })
+
+  tape('check that reduce has happened', function (t) {
+    t.ok(db.called)
+    db.called.get(null, function (err, count) {
+      console.log(err, count)
+      if (err) throw err
+      t.equal(count, 4)
+      t.end()
+    })
+  })
+
+  //  tape('get map with error', function (t) {
+  //    errorEnabled = true
+  //    db.append({foo: 13}, function (err, seq) {
+  //      if(err) throw err
+  //      console.log("GET", err, seq)
+  //      db.get(seq, function (err, value) {
+  //        console.log(  "GET", err, value)
+  //        t.ok(err)
+  //        t.end()
+  //      })
+  //    })
+  //  })
+  //
+
+  tape('close', function (t) {
+    db.close(function () {
+      t.end()
+    })
+  })
+}

--- a/test/util/memlog.js
+++ b/test/util/memlog.js
@@ -1,0 +1,166 @@
+var statistics = require('statistics')
+var pull = require('pull-stream')
+
+var tape = require('tape')
+
+var Reduce = require('flumeview-reduce')
+var Obv = require('obv')
+
+module.exports = function (db) {
+  db.use(
+    'stats',
+    Reduce(1, function (acc, data) {
+      return statistics(acc, data.foo)
+    })
+  )
+
+  tape('views', function (t) {
+    t.notEqual(db.views, undefined, 'views are accessible')
+    t.equal(Object.keys(db.views).length, 1, 'view count is correct')
+    t.end()
+  })
+
+  tape('empty db', function (t) {
+    t.ok(db.stats.close, 'stats view has close method')
+
+    db.stats.get(function (err, value) {
+      if (err) throw err
+      t.equal(value, undefined)
+      t.end()
+    })
+  })
+
+  tape('simple', function (t) {
+    db.since(function (v) {
+      console.log('SINCE', v)
+    }, false)
+
+    db.append({ foo: 1 }, function (err, seq) {
+      if (err) throw err
+      console.log('GET', err, seq, db.stats)
+      db.stats.get([], function (err, value) {
+        if (err) throw err
+        console.log('GET', value)
+        t.deepEqual(value.mean, 1)
+        t.deepEqual(value.stdev, 0)
+        t.end()
+      })
+    })
+  })
+
+  tape('append', function (t) {
+    db.append({ foo: 3 }, function (err, seq) {
+      if (err) throw err
+      console.log('GET', err, seq)
+      db.stats.get([], function (err, value) {
+        if (err) throw err
+        console.log('GET', value)
+        t.deepEqual(value.mean, 2)
+        t.deepEqual(value.stdev, 1)
+        t.end()
+      })
+    })
+  })
+
+  tape('get items in stream', function (t) {
+    pull(
+      db.stream({ seqs: true, values: false }),
+      pull.asyncMap(function (seq, cb) {
+        db.get(seq, cb)
+      }),
+      pull.collect(function (err, ary) {
+        if (err) throw err
+        t.deepEqual(ary, [{ foo: 1 }, { foo: 3 }])
+        t.end()
+      })
+    )
+  })
+
+  tape('disable ready to stall all reads', function (t) {
+    var called = false
+    db.ready.set(false)
+    db.stats.get([], function (err, value) {
+      t.error(err)
+      called = true
+    })
+    setTimeout(function () {
+      t.equal(db.ready.value, false)
+      t.equal(called, false)
+      db.ready.set(true)
+      t.equal(called, true) // this should fire immediately
+      t.end()
+    }, 100)
+  })
+
+  tape('rebuild a view that is ahead', function (t) {
+    var obv = Obv()
+    var since = db.since.value + 1
+    obv.set(since)
+    var reset = false
+    db.use('ahead', function (log, name) {
+      return {
+        methods: {},
+        since: obv,
+        createSink: function (opts) {
+          console.log(obv.value, db.since.value)
+          t.ok(
+            obv.value <= db.since.value,
+            'createSink should not be called unless within an acceptable range'
+          )
+          t.ok(reset)
+          t.end()
+        },
+        destroy: function (cb) {
+          reset = true
+          obv.set(-1)
+          cb()
+        },
+        close: function (cb) {
+          cb()
+        }
+      }
+    })
+  })
+
+  tape('throws if you *use* a view without close method', function (t) {
+    t.plan(1)
+    t.throws(() => {
+      db.use('naughtyView', function (log, name) {
+        return {
+          methods: {},
+          since: db.since,
+          createSink: function (opts) {},
+          destroy: function (cb) {}
+          // close: function (cb) { cb () } // << this is missing, so throw
+        }
+      })
+    }, /Error: FlumeDB view 'naughtyView' must implement method 'close'/)
+  })
+
+  tape('close', function (t) {
+    db.close(function () {
+      t.end()
+    })
+  })
+
+  tape('append after close', function (t) {
+    try {
+      db.append({ bar: 4 }, function (err, data, seq) {
+        t.error(err)
+        t.fail('should have thrown')
+      })
+    } catch (err) {
+      t.ok(err)
+      //      t.end()
+    }
+    try {
+      db.stats.get(function (err, data, seq) {
+        t.error(err)
+        t.fail('should have thrown')
+      })
+    } catch (err) {
+      t.ok(err)
+    }
+    t.end()
+  })
+}


### PR DESCRIPTION
History:
- travis wasn't running windows, so we swapped `set -e; for t in test/*.js .... ` for `tape test/*.js`
- unfortunately some of these files were BOTH:
  - a module to import and use for running tests
  - a standalone test in itself
- the tape version only output 78 tests ... but formally 128 were being run (or something)

The solution is to split things out a bit?
