### PR TITLE
Add abort() to rebuild to cancel old streams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,6 +1005,11 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
+    "pull-abortable": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz",
+      "integrity": "sha1-s61a77QRayWRbSbbiTk6yY0NzqE="
+    },
     "pull-cat": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cont": "^1.0.3",
     "explain-error": "^1.0.3",
     "obv": "0.0.1",
+    "pull-abortable": "^4.1.1",
     "pull-cont": "^0.1.1",
     "pull-looper": "^1.0.0",
     "pull-stream": "^3.6.14"

--- a/test/rebuild.js
+++ b/test/rebuild.js
@@ -44,7 +44,7 @@ tape('basic rebuild', (t) => {
             db.append({ foo: 4 }, function (err) {
               t.error(err, 'no error after append 4')
               db.append({ foo: 5 }, function (err) {
-                t.error(err, 'no error after append 4')
+                t.error(err, 'no error after append 5')
                 db.level.get(4, (err) => {
                   t.error(err, 'no error after level.get()')
                   db.close((err) => {

--- a/wrap.js
+++ b/wrap.js
@@ -112,7 +112,15 @@ module.exports = function wrap (sv, flume) {
       else sv.close(err, cb)
     },
     meta: meta,
-    destroy: sv.destroy
+    destroy: (cb) => {
+      o.destroying = true
+      sv.destroy((err) => {
+        o.destroying = false
+        cb(err)
+      })
+    },
+    destroying: false,
+    createSink: sv.createSink
   }
   if (!sv.methods) throw new Error('a stream view must have methods property')
 


### PR DESCRIPTION
Problem: During a rebuild we restart the view stream to `createSink()`
as soon as the previous stream closes. This creates a race condition
where the view has to choose between emptying the database and closing
the stream. If you close the stream first, the stream will restart
before you finish emptying the database. If you empty the database
first, you may receive new messages before the old stream is cancelled.
Handling all of the edge-cases in each individual view is hard.

Solution: Make FlumeDB abort the view streams to `createSink()` at the
beginning of the rebuild process, and be especially careful to prevent
the stream from restarting until the view's `destroy()` method is
completely finished. Managing this in FlumeDB should make it easier to
prevent race conditions and confusing database states.